### PR TITLE
Fixed GooglePlayValidator import in docs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -41,7 +41,7 @@ Google Play verification:
 -------------------------------------------------------------------------
 .. code:: python
 
-    from inapppy import GooglePlayVerifier, errors
+    from inapppy import GooglePlayValidator, errors
 
 
     def google_validator(in_receipt):


### PR DESCRIPTION
This PR corrects the import used in the README to use GooglePlayValidator instead of GooglePlayVerifier.